### PR TITLE
Explore TypeCheck advanced use-cases

### DIFF
--- a/lib/p.ex
+++ b/lib/p.ex
@@ -2,5 +2,4 @@ defmodule P do
   @moduledoc """
   P, as in Plaground; the global namespace of this repo
   """
-
 end

--- a/lib/playground/box.ex
+++ b/lib/playground/box.ex
@@ -1,0 +1,40 @@
+defmodule P.Box do
+  @moduledoc false
+
+  use TypeCheck
+
+  defstruct [
+    :height,
+    :width,
+    :depth,
+    :weight
+  ]
+
+  @type! height :: P.Length.t()
+  @type! width :: P.Length.t()
+  @type! depth :: P.Length.t()
+  @type! weight :: P.Weight.t()
+
+  @type! t() :: %__MODULE__{
+           height: height(),
+           width: width(),
+           depth: depth(),
+           weight: weight()
+         }
+
+  @spec! new(
+           P.Length.amount_t(),
+           P.Length.amount_t(),
+           P.Length.amount_t(),
+           P.Weight.amount_t(),
+           P.Length.unit_t()
+         ) :: t()
+  def new(height, width, depth, weight, unit \\ :cm) do
+    struct(__MODULE__, %{
+      height: P.Length.new(height, %{unit: unit}),
+      width: P.Length.new(width, %{unit: unit}),
+      depth: P.Length.new(depth, %{unit: unit}),
+      weight: P.Weight.new(weight, %{unit: :kg})
+    })
+  end
+end

--- a/lib/playground/distance.ex
+++ b/lib/playground/distance.ex
@@ -1,0 +1,8 @@
+defmodule P.Distance do
+  @moduledoc false
+
+  use P.Magnitude
+
+  @type! unit_t :: :km | :mi
+  @type! amount_t :: non_neg_integer()
+end

--- a/lib/playground/duration.ex
+++ b/lib/playground/duration.ex
@@ -1,29 +1,16 @@
 defmodule P.Duration do
   @moduledoc false
 
-  use TypeCheck
-  import TypeCheck.Type.StreamData
+  use P.Magnitude
 
-  defstruct [
-    :value,
-  ]
-
-  @type! unit :: :days
-  @type! my_numbers :: ((larger_than_3 :: number()) when larger_than_3 >= 3)
-                       |> wrap_with_gen(&P.Duration.gen/0)
-
-  @type! t() :: %__MODULE__{value: P.Magnitude.t(unit(), my_numbers())}
-
-  @type! opts :: %{unit: unit()}
-
-  @spec! new(my_numbers(), opts()) :: t()
-  def new(amount, %{unit: unit}) do
-    struct(__MODULE__, value: P.Magnitude.new(amount, %{unit: unit}))
-  end
+  @type! unit_t :: :days
+  @type! amount_t ::
+           (larger_than_3 :: number() when larger_than_3 >= 3)
+           |> wrap_with_gen(&P.Duration.gen/0)
 
   def gen() do
     StreamData.one_of([
-      StreamData.map(StreamData.positive_integer(), & &1 + 3),
+      StreamData.map(StreamData.positive_integer(), &(&1 + 3)),
       StreamData.float(min: 3.0)
     ])
   end

--- a/lib/playground/duration.ex
+++ b/lib/playground/duration.ex
@@ -2,20 +2,22 @@ defmodule P.Duration do
   @moduledoc false
 
   use TypeCheck
+  import TypeCheck.Type.StreamData
 
   defstruct [
     :value,
   ]
 
   @type! unit :: :days
-  @type! larger_than_3 :: number() when larger_than_3 >= 3
-    |> TypeCheck.Type.StreamData.wrap_with_gen(&P.Duration.gen/0)
+  @type! my_numbers :: ((larger_than_3 :: number()) when larger_than_3 >= 3)
+                       |> wrap_with_gen(&P.Duration.gen/0)
 
-  @type! t() :: %__MODULE__{value: P.Magnitude.t(unit(), larger_than_3())}
+  @type! t() :: %__MODULE__{value: P.Magnitude.t(unit(), my_numbers())}
 
-  @type! opts :: {:unit, unit()}
-  @spec! new(larger_than_3(), [opts()]) :: t()
-  def new(amount, unit: unit) do
+  @type! opts :: %{unit: unit()}
+
+  @spec! new(my_numbers(), opts()) :: t()
+  def new(amount, %{unit: unit}) do
     struct(__MODULE__, value: P.Magnitude.new(amount, %{unit: unit}))
   end
 

--- a/lib/playground/duration.ex
+++ b/lib/playground/duration.ex
@@ -1,0 +1,28 @@
+defmodule P.Duration do
+  @moduledoc false
+
+  use TypeCheck
+
+  defstruct [
+    :value,
+  ]
+
+  @type! unit :: :days
+  @type! larger_than_3 :: number() when larger_than_3 >= 3
+    |> TypeCheck.Type.StreamData.wrap_with_gen(&P.Duration.gen/0)
+
+  @type! t() :: %__MODULE__{value: P.Magnitude.t(unit(), larger_than_3())}
+
+  @type! opts :: {:unit, unit()}
+  @spec! new(larger_than_3(), [opts()]) :: t()
+  def new(amount, unit: unit) do
+    struct(__MODULE__, value: P.Magnitude.new(amount, %{unit: unit}))
+  end
+
+  def gen() do
+    StreamData.one_of([
+      StreamData.map(StreamData.positive_integer(), & &1 + 3),
+      StreamData.float(min: 3.0)
+    ])
+  end
+end

--- a/lib/playground/length.ex
+++ b/lib/playground/length.ex
@@ -1,0 +1,8 @@
+defmodule P.Length do
+  @moduledoc false
+
+  use P.Magnitude
+
+  @type! unit_t :: :cm | :in
+  @type! amount_t :: (i :: number() when i > 0)
+end

--- a/lib/playground/magnitude.ex
+++ b/lib/playground/magnitude.ex
@@ -5,16 +5,39 @@ defmodule P.Magnitude do
 
   defstruct [
     :unit,
-    :amount,
+    :amount
   ]
 
   @type! unit :: atom()
   @type! amount :: number()
 
-  @type! t(your_unit_type, your_amount_type) :: %__MODULE__{unit: your_unit_type, amount: your_amount_type}
+  @type! t(your_unit_type, your_amount_type) :: %__MODULE__{
+           unit: your_unit_type,
+           amount: your_amount_type
+         }
 
   @spec! new(amount(), %{unit: unit()}) :: t(unit(), amount())
   def new(amount, %{unit: unit}) do
     struct(__MODULE__, amount: amount, unit: unit)
+  end
+
+  defmacro __using__(_) do
+    quote location: :keep do
+      use TypeCheck
+      import TypeCheck.Type.StreamData
+
+      defstruct [
+        :value
+      ]
+
+      @type! t() :: %__MODULE__{value: P.Magnitude.t(unit_t(), amount_t())}
+
+      @type! opts :: %{unit: unit_t()}
+
+      @spec! new(amount_t(), opts()) :: t()
+      def new(amount, %{unit: unit}) do
+        struct(__MODULE__, value: P.Magnitude.new(amount, %{unit: unit}))
+      end
+    end
   end
 end

--- a/lib/playground/magnitude.ex
+++ b/lib/playground/magnitude.ex
@@ -1,0 +1,20 @@
+defmodule P.Magnitude do
+  @moduledoc false
+
+  use TypeCheck
+
+  defstruct [
+    :unit,
+    :amount,
+  ]
+
+  @type! unit :: atom()
+  @type! amount :: number()
+
+  @type! t(your_unit_type, your_amount_type) :: %__MODULE__{unit: your_unit_type, amount: your_amount_type}
+
+  @spec! new(amount(), %{unit: unit()}) :: t(unit(), amount())
+  def new(amount, %{unit: unit}) do
+    struct(__MODULE__, amount: amount, unit: unit)
+  end
+end

--- a/lib/playground/price.ex
+++ b/lib/playground/price.ex
@@ -1,0 +1,8 @@
+defmodule P.Price do
+  @moduledoc false
+
+  use P.Magnitude
+
+  @type! unit_t :: :usd | :cad
+  @type! amount_t :: number()
+end

--- a/lib/playground/weight.ex
+++ b/lib/playground/weight.ex
@@ -1,0 +1,8 @@
+defmodule P.Weight do
+  @moduledoc false
+
+  use P.Magnitude
+
+  @type! unit_t :: :kg | :lb
+  @type! amount_t :: (i :: number() when i > 0)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule P.MixProject do
   defp deps do
     [
       {:type_check, "~> 0.13.2"},
-      {:stream_data, "~> 0.5", only: :test},
+      {:stream_data, "~> 0.5", only: :test}
     ]
   end
 end

--- a/test/playground/box_test.exs
+++ b/test/playground/box_test.exs
@@ -1,25 +1,25 @@
-defmodule Playground.DurationTest do
+defmodule Playground.BoxTest do
   @moduledoc false
-  alias P.Duration
+  alias P.Box
 
   use ExUnit.Case, async: true
-  doctest Duration
+  doctest Box
 
   import TypeCheck.ExUnit
   import TypeCheck.Type.StreamData
   require TypeCheck.Type
 
-  spectest(Duration)
+  spectest(Box)
 
   describe "Explore StreamData" do
     test "produce" do
-      Duration.t()
+      Box.t()
       |> TypeCheck.Type.build()
       |> to_gen()
       |> Enum.take(100)
-      |> Enum.each(fn %Duration{} = e ->
-        assert e.value.unit == :days
-        assert e.value.amount >= 3
+      |> Enum.each(fn %Box{} = e ->
+        assert e.height.value.unit in [:cm, :in]
+        assert is_number(e.height.value.amount)
       end)
     end
   end

--- a/test/playground/distance_test.exs
+++ b/test/playground/distance_test.exs
@@ -16,7 +16,6 @@ defmodule Playground.DistanceTest do
       Distance.t()
       |> TypeCheck.Type.build()
       |> to_gen()
-      |> StreamData.resize(1000)
       |> Enum.take(100)
       |> Enum.each(fn %Distance{} = e ->
         assert e.value.unit in [:km, :mi]

--- a/test/playground/distance_test.exs
+++ b/test/playground/distance_test.exs
@@ -1,26 +1,26 @@
-defmodule Playground.DurationTest do
+defmodule Playground.DistanceTest do
   @moduledoc false
-  alias P.Duration
+  alias P.Distance
 
   use ExUnit.Case, async: true
-  doctest Duration
+  doctest Distance
 
   import TypeCheck.ExUnit
   import TypeCheck.Type.StreamData
   require TypeCheck.Type
 
-  spectest(Duration)
+  spectest(Distance)
 
   describe "Explore StreamData" do
     test "produce" do
-      Duration.t()
+      Distance.t()
       |> TypeCheck.Type.build()
       |> to_gen()
       |> StreamData.resize(1000)
       |> Enum.take(100)
-      |> Enum.each(fn %Duration{} = e ->
-        assert e.value.unit == :days
-        assert e.value.amount >= 3
+      |> Enum.each(fn %Distance{} = e ->
+        assert e.value.unit in [:km, :mi]
+        assert is_number(e.value.amount)
       end)
     end
   end

--- a/test/playground/duration_test.exs
+++ b/test/playground/duration_test.exs
@@ -1,0 +1,39 @@
+defmodule Playground.DurationTest do
+  @moduledoc false
+  alias P.Duration
+
+  use ExUnit.Case, async: true
+  doctest Duration
+
+  import TypeCheck.ExUnit
+  import TypeCheck.Type.StreamData
+  require TypeCheck.Type
+
+  spectest Duration
+
+  describe "Explore StreamData" do
+    test "produce" do
+      Duration.t()
+      |> TypeCheck.Type.build()
+      |> to_gen()
+      |> StreamData.resize(100)
+      |> Enum.take(10)
+      |> IO.inspect
+
+
+      # Sample output
+      # [
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 138}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -726}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -739}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 471}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 0.04419022263381974}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 0.30012254605626665}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -5.396406237314033e299}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -1.1053539504695976e300}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 753}},
+      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -7.247619303911501e300}}
+      # ]
+    end
+  end
+end

--- a/test/playground/duration_test.exs
+++ b/test/playground/duration_test.exs
@@ -16,24 +16,11 @@ defmodule Playground.DurationTest do
       Duration.t()
       |> TypeCheck.Type.build()
       |> to_gen()
-      |> StreamData.resize(100)
-      |> Enum.take(10)
-      |> IO.inspect
-
-
-      # Sample output
-      # [
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 138}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -726}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -739}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 471}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 0.04419022263381974}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 0.30012254605626665}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -5.396406237314033e299}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -1.1053539504695976e300}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: 753}},
-      #   %P.Duration{value: %P.Magnitude{unit: :days, amount: -7.247619303911501e300}}
-      # ]
+      |> StreamData.resize(1000)
+      |> Enum.take(100)
+      |> Enum.each(fn %Duration{} = e ->
+        assert e.value.amount >= 3
+      end)
     end
   end
 end

--- a/test/playground/length_test.exs
+++ b/test/playground/length_test.exs
@@ -1,25 +1,25 @@
-defmodule Playground.DurationTest do
+defmodule Playground.LengthTest do
   @moduledoc false
-  alias P.Duration
+  alias P.Length
 
   use ExUnit.Case, async: true
-  doctest Duration
+  doctest Length
 
   import TypeCheck.ExUnit
   import TypeCheck.Type.StreamData
   require TypeCheck.Type
 
-  spectest(Duration)
+  spectest(Length)
 
   describe "Explore StreamData" do
     test "produce" do
-      Duration.t()
+      Length.t()
       |> TypeCheck.Type.build()
       |> to_gen()
       |> Enum.take(100)
-      |> Enum.each(fn %Duration{} = e ->
-        assert e.value.unit == :days
-        assert e.value.amount >= 3
+      |> Enum.each(fn %Length{} = e ->
+        assert e.value.unit in [:cm, :in]
+        assert is_number(e.value.amount)
       end)
     end
   end

--- a/test/playground/magnitude_test.exs
+++ b/test/playground/magnitude_test.exs
@@ -9,7 +9,7 @@ defmodule Playground.MagnitudeTest do
   import TypeCheck.Type.StreamData
   require TypeCheck.Type
 
-  spectest Magnitude
+  spectest(Magnitude)
 
   defmodule TypeOverrides do
     use TypeCheck

--- a/test/playground/magnitude_test.exs
+++ b/test/playground/magnitude_test.exs
@@ -25,25 +25,10 @@ defmodule Playground.MagnitudeTest do
       |> TypeCheck.Type.build()
       |> to_gen()
       |> StreamData.resize(1000)
-      |> Enum.take(10)
-      |> IO.inspect
-
-
-      # SAMPLE OUTPUT
-      # [
-      #   %P.Magnitude{unit: :kg, amount: 572},
-      #   %P.Magnitude{unit: :kg, amount: -238},
-      #   %P.Magnitude{unit: :kg, amount: 662},
-      #   %P.Magnitude{unit: :kg, amount: -894},
-      #   %P.Magnitude{unit: :kg, amount: -673},
-      #   %P.Magnitude{unit: :kg, amount: -332},
-      #   %P.Magnitude{unit: :kg, amount: -118},
-      #   %P.Magnitude{unit: :kg, amount: 951},
-      #   %P.Magnitude{unit: :kg, amount: 717},
-      #   %P.Magnitude{unit: :kg, amount: 610}
-      # ]
-      # .
-      # Finished in 0.4 seconds (0.4s async, 0.00s sync)
+      |> Enum.take(100)
+      |> Enum.each(fn %Magnitude{} = e ->
+        assert is_integer(e.amount)
+      end)
     end
   end
 end

--- a/test/playground/magnitude_test.exs
+++ b/test/playground/magnitude_test.exs
@@ -1,0 +1,49 @@
+defmodule Playground.MagnitudeTest do
+  @moduledoc false
+  alias P.Magnitude
+
+  use ExUnit.Case, async: true
+  doctest Magnitude
+
+  import TypeCheck.ExUnit
+  import TypeCheck.Type.StreamData
+  require TypeCheck.Type
+
+  spectest Magnitude
+
+  defmodule TypeOverrides do
+    use TypeCheck
+
+    @type! unit :: :kg
+    @type! amount :: integer()
+    @type! t(your_amount_type) :: P.Magnitude.t(unit(), your_amount_type)
+  end
+
+  describe "Explore StreamData" do
+    test "produce" do
+      TypeOverrides.t(TypeOverrides.amount())
+      |> TypeCheck.Type.build()
+      |> to_gen()
+      |> StreamData.resize(1000)
+      |> Enum.take(10)
+      |> IO.inspect
+
+
+      # SAMPLE OUTPUT
+      # [
+      #   %P.Magnitude{unit: :kg, amount: 572},
+      #   %P.Magnitude{unit: :kg, amount: -238},
+      #   %P.Magnitude{unit: :kg, amount: 662},
+      #   %P.Magnitude{unit: :kg, amount: -894},
+      #   %P.Magnitude{unit: :kg, amount: -673},
+      #   %P.Magnitude{unit: :kg, amount: -332},
+      #   %P.Magnitude{unit: :kg, amount: -118},
+      #   %P.Magnitude{unit: :kg, amount: 951},
+      #   %P.Magnitude{unit: :kg, amount: 717},
+      #   %P.Magnitude{unit: :kg, amount: 610}
+      # ]
+      # .
+      # Finished in 0.4 seconds (0.4s async, 0.00s sync)
+    end
+  end
+end

--- a/test/playground/price_test.exs
+++ b/test/playground/price_test.exs
@@ -16,7 +16,6 @@ defmodule Playground.PriceTest do
       Price.t()
       |> TypeCheck.Type.build()
       |> to_gen()
-      |> StreamData.resize(1000)
       |> Enum.take(100)
       |> Enum.each(fn %Price{} = e ->
         assert e.value.unit in [:cad, :usd]

--- a/test/playground/price_test.exs
+++ b/test/playground/price_test.exs
@@ -1,26 +1,26 @@
-defmodule Playground.DurationTest do
+defmodule Playground.PriceTest do
   @moduledoc false
-  alias P.Duration
+  alias P.Price
 
   use ExUnit.Case, async: true
-  doctest Duration
+  doctest Price
 
   import TypeCheck.ExUnit
   import TypeCheck.Type.StreamData
   require TypeCheck.Type
 
-  spectest(Duration)
+  spectest(Price)
 
   describe "Explore StreamData" do
     test "produce" do
-      Duration.t()
+      Price.t()
       |> TypeCheck.Type.build()
       |> to_gen()
       |> StreamData.resize(1000)
       |> Enum.take(100)
-      |> Enum.each(fn %Duration{} = e ->
-        assert e.value.unit == :days
-        assert e.value.amount >= 3
+      |> Enum.each(fn %Price{} = e ->
+        assert e.value.unit in [:cad, :usd]
+        assert is_number(e.value.amount)
       end)
     end
   end


### PR DESCRIPTION
## Objective

Any measurement can be expressed as a magnitude:
* 3 km
* 3 seconds
* 3 USD

So given an abstract type `Magnitude`; the desire is to reuse it to implement `Measurement`, `Duration`, `Price` etc. while leveraging TypeCheck in the process.


## Update
The main learnings that I obtained here:

* Originally, I was under the mistaken impression that `TypeCheck` would do `spectest` for both the succeeding as well as the failing cases. In actual fact, only the succeeding cases are being tested as the latter requires the ability to find the inverse, complement type of any given type; which in its strictest sense is an idea unfeasible to realize in StreamData: https://github.com/whatyouhide/stream_data/issues/100
* You can use `type guards` and `parameterized types` to reuse entire structs with all the benefits that TypeCheck provides out of the box
   * In the case of `type guards`; it is important to realize that you also will need to [manually implement your own property generator](https://github.com/Ajwah/type_check_playground/blob/60a285ae13b6accbcfb4c28c778cbab617dbfac3/lib/playground/duration.ex#L9-L16). By default; `TypeCheck` will only cater for [filtering out the types that do not correspond dynamically](https://github.com/Qqwy/elixir-type_check/blob/main/lib/type_check/builtin/guarded.ex#L172-L173); which can easily end up `StreamData` raising the the infamous: `StreamData.FilterTooNarrowError)`-exception.

